### PR TITLE
Change import from misc to special for comb

### DIFF
--- a/ecopy/diversity/rarefy.py
+++ b/ecopy/diversity/rarefy.py
@@ -1,6 +1,6 @@
 import numpy as np
 from pandas import DataFrame
-from scipy.misc import comb
+from scipy.special import comb
 import matplotlib.pyplot as plt
 
 def rarefy(x, method='rarefy', size = None, breakNA=True):


### PR DESCRIPTION
Hello,

Thanks for this module :)
I was trying to use ecopy with the latest scipy 1.3
and I noticed that the function `comb` is not anymore in the `scipy.misc` submodule,
but on the `scipy.special`.

This is a minor change, so I hope it is OK.

Thanks for your time!